### PR TITLE
Add locking functionality to PUT method

### DIFF
--- a/lib/resty/consul.lua
+++ b/lib/resty/consul.lua
@@ -85,7 +85,7 @@ end
 
 local function _get(httpc, key, opts)
     local uri = build_uri(key, opts)
-    
+
     local res, err = httpc:request({path = uri})
     if not res then
         return nil, err


### PR DESCRIPTION
Also: 

Don't safe_json_decode nil body values from PUT

Use ngx.encode_args instead of table concat for request options

json_encode table or boolean values passed into PUT
