### PR TITLE
check for content-type before trying to decode

### DIFF
--- a/lib/resty/consul.lua
+++ b/lib/resty/consul.lua
@@ -107,7 +107,11 @@ local function _get(httpc, key, opts)
         return nil, err
     end
 
-    local response = safe_json_decode(body)
+    local response = {}
+    if res.headers.content_type == 'application/json' then
+	    response = safe_json_decode(body)
+    end
+
     local headers = res.headers
     return response, headers["X-Consul-Lastcontact"], headers["X-Consul-Knownleader"], headers["X-Consul-Index"]
 end


### PR DESCRIPTION
deregester service one endpoint that returns empty 200 /v1/agent/service/deregister/<serviceid>