### PR TITLE
Fixing typo and self links in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Library to interface with the consul HTTP API from ngx_lua
     * [put_key](#put_key)
     * [delete_key](#delete_key)
     * [list_keys](#list_keys)
-* [Transaction helper](#transaction_helper)
+* [Transaction Helper](#transaction_helper)
 
 # Overview
 
@@ -208,7 +208,7 @@ Returns a [lua-resty-http](https://github.com/pintsized/lua-resty-http) response
 On error returns `nil` and an error message.
 
 
-# Transaction helper
+# Transaction Helper
 
 ### txn
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Library to interface with the consul HTTP API from ngx_lua
     * [put_key](#put_key)
     * [delete_key](#delete_key)
     * [list_keys](#list_keys)
-* [Transaction helpter](#transaction_helper)
+* [Transaction helper](#transaction_helper)
 
 # Overview
 

--- a/README.md
+++ b/README.md
@@ -7,18 +7,18 @@ Library to interface with the consul HTTP API from ngx_lua
 
 * [Overview](#overview)
 * [Dependencies](#dependencies)
-* [Basic Methods](#basic_methods)
+* [Basic Methods](#basic-methods)
     * [new](#new)
     * [get](#get)
     * [put](#put)
     * [delete](#delete)
     * [get_client_body_reader](#get_client_body_reader)
-* [Key Value helpers](#key_value_helpers)
+* [Key Value helpers](#key-value-helpers)
     * [get_key](#get_key)
     * [put_key](#put_key)
     * [delete_key](#delete_key)
     * [list_keys](#list_keys)
-* [Transaction Helper](#transaction_helper)
+* [Transaction Helper](#transaction-helper)
 
 # Overview
 


### PR DESCRIPTION
fixed following things

1. fixed typo transaction helpter -> transaction helper
2. fixed self links to multi word headings like Basic methods and transaction helpers by replacing underscore to hyphen for white spaces.